### PR TITLE
Add forwards-compatibility for iframe-embedded features

### DIFF
--- a/django_code/program/templates/program/index.html
+++ b/django_code/program/templates/program/index.html
@@ -77,6 +77,8 @@
 
     <script>
         var runningLocal = false;
+        
+        document.domain = "ourjseditor.com";
 
         try {
             var programData = JSON.parse('{{ data_dict|escapejs }}')


### PR DESCRIPTION
Adds forwards-compatibility for possible future features (like, say, a non-abusable alert system) by allowing slightly relaxed communication. Should just be able to set `document.domain = "ourjseditor.com"` in a hardcoded script inside the iframe to send messages out to the parent page. If this gets accepted, you guys should note this snippet for future use.

And yes, I know this is tiny, but gotta go through the motions amirait?