### PR TITLE
Fix notifications not being able to be marked as read.

### DIFF
--- a/django_code/notification/api.py
+++ b/django_code/notification/api.py
@@ -19,7 +19,7 @@ def notif(request, notif_id):
         if request.user != requested_notif.target_user:
             return api.error("Not authorized", status=401)
 
-        if isinstance(read, bool):
+        if not isinstance(read, bool):
             return api.error("Invalid type for key \"isRead\"")
 
         requested_notif.is_read = read


### PR DESCRIPTION
Just a typo fix.
A previous commit accidentally made it such that when the user marks a notif as read, the backend would reject with a 400 Invalid type for key "isRead".

Disclaimer: I have not tested this, as I haven't been able to setup a dev environment locally. Also, this is my 1st pull request, and I'm sure there's a lot I don't know about how all this works. 
Thanks!