### PR TITLE
Update vote API to use JSON instead of query parameters.

### DIFF
--- a/django_code/program/static/program/program.js
+++ b/django_code/program/static/program/program.js
@@ -1079,7 +1079,7 @@ function vote () {
     var hasVoted = programData.hasVoted[voteType];
 
     var req = new XMLHttpRequest();
-    req.open(hasVoted ? "POST" : "DELETE", "/api/program/" + programData.id + "/vote?type=" + voteType);
+    req.open(hasVoted ? "POST" : "DELETE", "/api/program/" + programData.id + "/vote");
     req.setRequestHeader("X-CSRFToken", csrf_token);
     req.addEventListener("load", function () {
         var d = JSON.parse(this.response);
@@ -1098,7 +1098,9 @@ function vote () {
             document.getElementById(voteType + "-vote-count").innerHTML = programData.votes[voteType];
         }
     });
-    req.send();
+    req.send(JSON.stringify({
+        type: voteType
+    }));
 }
 
 function save (fork) {

--- a/django_code/vote/api.py
+++ b/django_code/vote/api.py
@@ -1,9 +1,6 @@
 from __future__ import unicode_literals
 
-try:
-    from urllib.parse import parse_qs
-except ImportError:
-    from urlparse import parse_qs
+import json
 
 from ourjseditor import api
 from program.models import Program
@@ -14,7 +11,7 @@ from .models import Vote, vote_types
 @api.StandardAPIErrors("POST", "DELETE")
 @api.login_required
 def program_vote(request, program_id):
-    vote_type = parse_qs(request.META["QUERY_STRING"])["type"][0]
+    vote_type = json.loads(request.body)["type"]
 
     if vote_type not in vote_types:
         return api.error("Invalid vote type.")


### PR DESCRIPTION
A fairly simple update to the vote API endpoint to use JSON like the rest of the API, with corresponding changes on the front end.

Fixes #58.