### PR TITLE
Comment style fixing

### DIFF
--- a/django_code/program/static/program/program.css
+++ b/django_code/program/static/program/program.css
@@ -486,7 +486,16 @@ input, textarea {
 
 .comment table {
     border-collapse: collapse;
+    table-layout: fixed;
     width: 100%;
+}
+
+.comment td {
+    overflow: auto;
+}
+
+.comment code {
+    white-space: nowrap;
 }
 
 .comment-content {
@@ -519,6 +528,14 @@ input, textarea {
 
 .comment-comment {
     margin-left: 40px;
+}
+
+.comment-adding table {
+    table-layout: initial;
+}
+
+.comment-adding td {
+    overflow: initial;
 }
 
 .comment-adding td:last-child {


### PR DESCRIPTION
Fixes #180. This PR tweaks the comment CSS so that long comments with code have a scrollbar, instead of the text extending off the screen.